### PR TITLE
Fixing asana python package version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - [Python](https://www.python.org) >= 3
 - Official [Asana](https://github.com/Asana/python-asana) Python package.
 
-You **must install** the official Asana package using: `pip3 install asana --user`
+You **must install** the official Asana 2.0.0 package using: `pip3 install asana==2.0.0 --user`
 
 ## Install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-asana
+asana==2.0.0


### PR DESCRIPTION
@inigopascall sorry for the delay :heart:, the issue is that I didn't fix the version of the asana api requirement, I've updated the documentation, now when installing the package you should fix the version to 2.0.0 I tested locally and it should be working.

I'm not using Asana anymore, but I'm happy to help if you use the extension.